### PR TITLE
RCE-Fixed

### DIFF
--- a/datalab/utils/commands/_utils.py
+++ b/datalab/utils/commands/_utils.py
@@ -324,7 +324,7 @@ def parse_config(config, env, as_dict=True):
   elif stripped[0] == '{':
     config = json.loads(config)
   else:
-    config = yaml.load(config)
+    config = yaml.safe_load(config)
   if as_dict:
     config = dict(config)
 


### PR DESCRIPTION
:pencil2: Change Description
:bar_chart: Metadata *

Google Cloud Datalab Python package. Used in Google Cloud Datalab and can be used in Jupyter Notebook.
This adds a number of Python modules such as google.datalab.bigquery, google.datalab.storage, etc, for accessing Google Cloud Platform services as well as adding some new cell magics such as %chart, %bigquery, %storage, etc.
See https://github.com/googledatalab/notebooks for samples of using this package.

Bounty URL: https://www.huntr.dev/bounties/1-pip-datalab
:gear: Description *

Vulnerable to YAML deserialization attack caused by unsafe loading.

:computer: Technical Description *

Fixed by avoiding unsafe loader.

:bug: Proof of Concept (PoC) *

Create the following PoC file:
exploit.py

```
import os
os.system('pip install datalab')
import datalab.utils.commands._utils as _utils 
exploit = '''!!python/object/new:type
  args: ["z", !!python/tuple [], {"extend": !!python/name:exec }]
  listitems: "__import__('os').system('xcalc')"
'''
_utils.parse_config(exploit ,None)
```

Execute the commands in another terminal:

```
#use
pip install PyYAML==3.12
ipython3
```

    Check the Output:

![](https://drive.google.com/file/d/1rOiv8yNC4DNlJiF_vizDHOopbmYmcAwE/view?usp=sharing)
xcalc will pop up.

:fire: Proof of Fix (PoF) *

![](https://drive.google.com/file/d/1SR67Y8GKY2PppcHaqkMrRUqSDo40dNL4/view?usp=sharing)
After fix it will not popup a calc.

:+1: User Acceptance Testing (UAT)

After fix functionality is unaffected.